### PR TITLE
fix xml header with short_open_tags enabled

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?php echo '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL; ?>
 <urlset xmlns="http://www.google.com/schemas/sitemap/0.90">
     @foreach ($content as $entry)
         <url>


### PR DESCRIPTION
If php short open tags are enabled the sitemap does not work

    Next ErrorException: Parse error: syntax error, unexpected 'version' (T_STRING) (View: /.../addons/Sitemap/resources/views/index.blade.php) in /.../storage/framework/views/12a800270cbd715a1bb90dd93cd730f8:1
