### PR TITLE
fix the xml namespace

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,5 +1,5 @@
 <?php echo '<?xml version="1.0" encoding="UTF-8"?>' . PHP_EOL; ?>
-<urlset xmlns="http://www.google.com/schemas/sitemap/0.90">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     @foreach ($content as $entry)
         <url>
             <loc>{{ $entry['url'] }}</loc>


### PR DESCRIPTION
The correct namespace should be `http://www.sitemaps.org/schemas/sitemap/0.9`
Google Search console shows following error:
```
Your Sitemap or Sitemap index file doesn't properly declare the namespace.
Expected: http://www.sitemaps.org/schemas/sitemap/0.9
Found: http://www.google.com/schemas/sitemap/0.90
Tag: urlset 
```

https://support.google.com/webmasters/answer/183668?hl=en